### PR TITLE
Add setLocalTime method

### DIFF
--- a/android/src/main/kotlin/dev/rexios/polar/PolarPlugin.kt
+++ b/android/src/main/kotlin/dev/rexios/polar/PolarPlugin.kt
@@ -40,6 +40,7 @@ import io.reactivex.rxjava3.disposables.Disposable
 import java.lang.reflect.Type
 import java.util.Date
 import java.util.UUID
+import java.util.Calendar
 
 fun Any?.discard() = Unit
 
@@ -156,6 +157,7 @@ class PolarPlugin :
             "doFactoryReset" -> doFactoryReset(call, result)
             "enableSdkMode" -> enableSdkMode(call, result)
             "disableSdkMode" -> disableSdkMode(call, result)
+            "setLocalTime" -> setLocalTime(call,result)
             "isSdkModeEnabled" -> isSdkModeEnabled(call, result)
             else -> result.notImplemented()
         }
@@ -247,6 +249,30 @@ class PolarPlugin :
             })
             .discard()
     }
+
+    private fun setLocalTime(
+        call: MethodCall,
+        result: Result
+    ) {
+        val identifier = call.arguments as String
+        val calendar = Calendar.getInstance()
+        calendar.time = Date()
+
+        wrapper.api
+            .setLocalTime(identifier, calendar)
+            .subscribe(
+                {
+                    runOnUiThread { result.success(null) }
+                },
+                {
+                    runOnUiThread {
+                        result.error(it.toString(), it.message, null)
+                    }
+                }
+            )
+            .discard()
+    }
+
 
     private fun requestStreamSettings(
         call: MethodCall,

--- a/ios/Classes/SwiftPolarPlugin.swift
+++ b/ios/Classes/SwiftPolarPlugin.swift
@@ -3,6 +3,7 @@ import Flutter
 import PolarBleSdk
 import RxSwift
 import UIKit
+import Foundation
 
 private let encoder = JSONEncoder()
 private let decoder = JSONDecoder()
@@ -106,6 +107,8 @@ public class SwiftPolarPlugin:
         removeExercise(call, result)
       case "setLedConfig":
         setLedConfig(call, result)
+      case "setLocalTime":
+        setLocalTime(call, result)
       case "doFactoryReset":
         doFactoryReset(call, result)
       case "enableSdkMode":
@@ -349,6 +352,26 @@ public class SwiftPolarPlugin:
         result(
           FlutterError(
             code: "Error setting led config", message: error.localizedDescription, details: nil))
+      })
+  }
+
+  func setLocalTime(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    let identifier = call.arguments as! String
+    let time: Date = Date()
+    let timeZone = TimeZone.current
+
+    _ = api.setLocalTime(
+      identifier, 
+      time:time, 
+      zone:timeZone
+    ).subscribe(
+      onCompleted: {
+        result(nil)
+      },
+      onError: { error in
+        result(
+          FlutterError(
+            code: "Error setting local time", message: error.localizedDescription, details: nil))     
       })
   }
 

--- a/lib/src/polar_base.dart
+++ b/lib/src/polar_base.dart
@@ -537,6 +537,11 @@ class Polar {
     );
   }
 
+  /// Set local time of the device
+  Future<void> setLocalTime(String identifier) {
+    return _channel.invokeMethod('setLocalTime', identifier);
+  }
+
   ///  Enables SDK mode.
   Future<void> enableSdkMode(String identifier) {
     return _channel.invokeMethod('enableSdkMode', identifier);


### PR DESCRIPTION
Adds the setLocalTime method to set the device's time to local time.
Known issue on verity sense and OH1 from the official sdk documentation: the change will only occur after restarting the device.