### PR TITLE
Migrate to built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.10.2
+
+- Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+- Migrates to built-in Kotlin
+
 ## 7.10.1
 
 - Dependency upgrades

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ group 'dev.rexios.polar'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -24,7 +22,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     compileSdk 36
@@ -42,16 +39,16 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = '11'
-    }
-
     namespace "dev.rexios.polar"
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
+dependencies {
     // Dependencies for Polar SDK
     api 'com.github.polarofficial:polar-ble-sdk:6.14.0'
     implementation 'io.reactivex.rxjava3:rxjava:3.1.12'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -4,3 +4,5 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.newDsl=false
+android.builtInKotlin=false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: polar
 description: This is a Dart plugin wrapper for the Polar SDK on Android and iOS
-version: 7.10.1
+version: 7.10.2
 homepage: https://github.com/Rexios80/polar
 
 environment:
-  sdk: ^3.8.0
-  flutter: ">=1.12.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- Migrates the plugin to built-in Kotlin: removes the explicit Kotlin Gradle Plugin usage (`apply plugin: 'kotlin-android'`, the `kotlin-gradle-plugin` buildscript classpath, `ext.kotlin_version`, and the explicit `kotlin-stdlib` dependency) and adds a `kotlin { compilerOptions { jvmTarget = ... } }` block.
- Raises minimum SDK to Flutter 3.44 / Dart 3.12, patch-bumps the version, and adds a CHANGELOG entry.
- Migrates the example app per the [app-developer guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers) (adds `android.builtInKotlin=false` / `android.newDsl=false`, removes the `kotlin-android` plugin and `kotlinOptions` where present). No AGP upgrade.

See the [plugin-author migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).

## Test plan
- [ ] CI passes
- [ ] Example builds after the separate AGP 9 upgrade

Made with [Cursor](https://cursor.com)